### PR TITLE
Feature/create tests for color palette  tdd

### DIFF
--- a/2do.md
+++ b/2do.md
@@ -253,12 +253,12 @@ Download and extract the [Resources](#resources) into your project folder.
 
 #### Acceptance Criteria
 
-- [ ] All favorite flags and comments added to art pieces are persisted across browser reloads
+- [x] All favorite flags and comments added to art pieces are persisted across browser reloads
 
 #### Tasks
 
-- [ ] Install the package `use-local-storage-state`
-- [ ] Use the `useLocalStorageState` hook to store the `artPiecesInfo` state
+- [x] Install the package `use-local-storage-state`
+- [x] Use the `useLocalStorageState` hook to store the `artPiecesInfo` state
 
 To use the `useImmer` hook to mutate the `artPiecesInfo` state, implement this example to combine both.
 
@@ -325,7 +325,7 @@ export default function App({ Component, pageProps }) {
 
 - [ ] Pass the `colors` given by the API to the `ArtPieceDetails` component 🖼️
 - [ ] Use the color hex-code in a styled component to render an element with this color as background
-- [ ] All acceptance criteria marked with 🖼️ are covered by component testing
+- [x] All acceptance criteria marked with 🖼️ are covered by component testing
 
 ---
 

--- a/components/ArtPieceDetails/ArtPieceDetails.test.js
+++ b/components/ArtPieceDetails/ArtPieceDetails.test.js
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { ArtPieceDetails } from "..";
+import { demoPieces } from "../../_testData/testData";
+
+describe("Art Pieces Details Color-Palette Tests", () => {
+  //
+  it("should receive the colors props and render the colors with the hex codes as titles", () => {
+    render(<ArtPieceDetails {...demoPieces[0]} />);
+    const liElement = screen.getByTitle("#0f5855");
+    expect(liElement).toBeInTheDocument();
+  });
+
+  it("should render 5 list items, 1 for each color", () => {
+    render(<ArtPieceDetails {...demoPieces[0]} />);
+    const liElements = screen.getAllByTestId("color-palette-listitem");
+    expect(liElements.length).toBe(5);
+  });
+});


### PR DESCRIPTION
Create 2 tests for color palette feature before its implementation (TDD)

Both tests are failing right now and are waiting for the correct code to be implemented in the ArtPieceDetails component (see #34).
So this is basically Test-Driven-Development. :)
- [x] One tests checks if there a list item with the hex code of one of the colors
of the rendered piece.
- [x] The other test checks if there a actually all 5 colors rendered as list items.